### PR TITLE
SVG Export

### DIFF
--- a/EJSChart.js
+++ b/EJSChart.js
@@ -2316,8 +2316,14 @@
 					return false;
 				};
 				if (this.caption == undefined) { this.caption = "Axis Caption"; }
-				if (this.__orientation == "h" || EJSC.__isIE || getTransformProperty(document.body) ) { return '<span>' + this.caption + '</span>'; }
-				else { return '<span>' + this.caption.split("").join("<br/>") + '</span>'; }
+				/*span tags cause the exported svg axis titles, increments, and graph title to be jumbled*/
+				//if (this.__orientation == "h" || EJSC.__isIE || getTransformProperty(document.body) ) { return '<span>' + this.caption + '</span>'; }
+
+				if (this.__orientation == "h" || EJSC.__isIE || getTransformProperty(document.body) ) { return this.caption ; }
+				
+				/*span tags cause the exported svg axis titles, increments, and graph title to be jumbled*/
+				//else { return '<span>' + this.caption.split("").join("<br/>") + '</span>'; }
+				else { return  this.caption.split("").join("<br/>") ; }
 			},
 			__canDraw: function() {
 				return ((this.visible == true && this.__series.length > 0) ||


### PR DESCRIPTION
I noticed that the exportSVG function wraps the X and Y axis titles in span tags.  This causes the exported axis titles, graph title, and graphing increments to appear jumbled and centered beneath the actual graph.  Removing the addition of span tags in the JS on line 2319 fixes this issue and allows the svg graph to be formatted correctly
